### PR TITLE
Add new blog post: "今天和 Codex 一起写博客" (2026-03-21)

### DIFF
--- a/2019/08/01/hello-world/index.html
+++ b/2019/08/01/hello-world/index.html
@@ -389,7 +389,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2019/08/02/esse/index.html
+++ b/2019/08/02/esse/index.html
@@ -397,7 +397,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2019/08/05/jstest/index.html
+++ b/2019/08/05/jstest/index.html
@@ -387,7 +387,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2019/08/13/tf_train/index.html
+++ b/2019/08/13/tf_train/index.html
@@ -420,7 +420,7 @@ print(&quot;W: %s b: %s loss: %s&quot;%(curr_W, curr_b, curr_loss))</code></pre>
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2019/08/15/KNN/index.html
+++ b/2019/08/15/KNN/index.html
@@ -431,7 +431,7 @@ plt.show()</code></pre>
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2019/11/11/hjmgxl/index.html
+++ b/2019/11/11/hjmgxl/index.html
@@ -387,7 +387,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2019/11/27/zed/index.html
+++ b/2019/11/27/zed/index.html
@@ -368,7 +368,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2020/01/01/xnkl/index.html
+++ b/2020/01/01/xnkl/index.html
@@ -388,7 +388,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2020/02/18/happy/index.html
+++ b/2020/02/18/happy/index.html
@@ -395,7 +395,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2020/03/31/20200331/index.html
+++ b/2020/03/31/20200331/index.html
@@ -387,7 +387,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2020/05/10/5.10/index.html
+++ b/2020/05/10/5.10/index.html
@@ -385,7 +385,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2020/11/03/0113/index.html
+++ b/2020/11/03/0113/index.html
@@ -385,7 +385,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2021/06/25/csgo/index.html
+++ b/2021/06/25/csgo/index.html
@@ -385,7 +385,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2021/06/25/yaha/index.html
+++ b/2021/06/25/yaha/index.html
@@ -387,7 +387,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2021/10/24/1024/index.html
+++ b/2021/10/24/1024/index.html
@@ -395,7 +395,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2022/01/21/20220121/index.html
+++ b/2022/01/21/20220121/index.html
@@ -385,7 +385,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2022/04/13/0413/index.html
+++ b/2022/04/13/0413/index.html
@@ -386,7 +386,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2022/06/03/20220603/index.html
+++ b/2022/06/03/20220603/index.html
@@ -385,7 +385,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2022/06/20/20220620/index.html
+++ b/2022/06/20/20220620/index.html
@@ -387,7 +387,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2022/07/04/20220704/index.html
+++ b/2022/07/04/20220704/index.html
@@ -384,7 +384,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2022/09/07/20220907/index.html
+++ b/2022/09/07/20220907/index.html
@@ -407,7 +407,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2022/10/08/20221008/index.html
+++ b/2022/10/08/20221008/index.html
@@ -378,7 +378,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2022/12/23/20221223/index.html
+++ b/2022/12/23/20221223/index.html
@@ -376,7 +376,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2023/01/30/20230130/index.html
+++ b/2023/01/30/20230130/index.html
@@ -396,7 +396,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2023/04/17/20230417/index.html
+++ b/2023/04/17/20230417/index.html
@@ -329,6 +329,10 @@
           <span class="post-nav-divider"></span>
 
           <div class="post-nav-prev post-nav-item">
+              <a href="/2026/03/21/codex-journey/" rel="prev" title="今天和 Codex 一起写博客">
+                今天和 Codex 一起写博客 <i class="fa fa-chevron-right"></i>
+              </a>
+            
           </div>
         </div>
     </footer>
@@ -384,7 +388,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/2026/03/21/codex-journey/index.html
+++ b/2026/03/21/codex-journey/index.html
@@ -57,19 +57,21 @@
   };
 </script>
 
-  <meta name="description" content="中秋节happy~">
+  <meta name="description" content="2026年3月21日，我认真记录下和 Codex 一起折腾博客的一天：从一个想法开始，到页面真正落地，像是给平常的周末偷偷加了一点魔法。">
 <meta name="keywords" content="easy to clee happy life">
 <meta property="og:type" content="article">
-<meta property="og:title" content="大家中秋快乐啊">
-<meta property="og:url" content="http://yoursite.com/2019/09/14/zqkl/index.html">
+<meta property="og:title" content="今天和 Codex 一起写博客">
+<meta property="og:url" content="http://yoursite.com/2026/03/21/codex-journey/index.html">
 <meta property="og:site_name" content="saber~">
-<meta property="og:description" content="中秋节happy~">
+<meta property="og:description" content="2026年3月21日，我认真记录下和 Codex 一起折腾博客的一天：从一个想法开始，到页面真正落地，像是给平常的周末偷偷加了一点魔法。">
 <meta property="og:locale" content="zh-CN">
-<meta property="og:updated_time" content="2019-09-14T05:02:59.009Z">
+<meta property="og:image" content="/images/saber_cute.png">
+<meta property="og:updated_time" content="2026-03-21T12:26:00.000Z">
 <meta name="twitter:card" content="summary">
-<meta name="twitter:title" content="大家中秋快乐啊">
-<meta name="twitter:description" content="中秋节happy~">
-  <link rel="canonical" href="http://yoursite.com/2019/09/14/zqkl/">
+<meta name="twitter:title" content="今天和 Codex 一起写博客">
+<meta name="twitter:description" content="2026年3月21日，我认真记录下和 Codex 一起折腾博客的一天：从一个想法开始，到页面真正落地，像是给平常的周末偷偷加了一点魔法。">
+<meta name="twitter:image" content="/images/saber_cute.png">
+  <link rel="canonical" href="http://yoursite.com/2026/03/21/codex-journey/">
 
 
 <script id="page.configurations">
@@ -78,7 +80,7 @@
   };
 </script>
 
-  <title>大家中秋快乐啊 | saber~</title>
+  <title>今天和 Codex 一起写博客 | saber~</title>
   
 
 
@@ -244,7 +246,7 @@
   
   
   <div class="post-block">
-    <link itemprop="mainEntityOfPage" href="http://yoursite.com/2019/09/14/zqkl/">
+    <link itemprop="mainEntityOfPage" href="http://yoursite.com/2026/03/21/codex-journey/">
 
     <span hidden itemprop="author" itemscope itemtype="http://schema.org/Person">
       <meta itemprop="name" content="machi">
@@ -258,7 +260,7 @@
       <header class="post-header">
 
         
-          <h1 class="post-title" itemprop="name headline">大家中秋快乐啊
+          <h1 class="post-title" itemprop="name headline">今天和 Codex 一起写博客
 
               
             
@@ -278,7 +280,7 @@
                 
               
 
-              <time title="创建时间：2019-09-14 13:00:51 / 修改时间：13:02:59" itemprop="dateCreated datePublished" datetime="2019-09-14T13:00:51+08:00">2019-09-14</time>
+              <time title="创建时间：2026-03-21 20:26:00 / 修改时间：20:26:00" itemprop="dateCreated datePublished" datetime="2026-03-21T20:26:00+08:00">2026-03-21</time>
             </span>
           
             
@@ -306,7 +308,9 @@
     <div class="post-body" itemprop="articleBody">
 
       
-        <h2 id="中秋节"><a href="#中秋节" class="headerlink" title="中秋节"></a>中秋节</h2><p>happy~</p>
+        <h2 id="把一个念头交给-Codex"><a href="#把一个念头交给-Codex" class="headerlink" title="把一个念头交给 Codex"></a>把一个念头交给 Codex</h2><p>2026 年 3 月 21 日，我做了一件很简单、又让我有点兴奋的事情：把“想写一篇博客”这个念头交给了 Codex。以前我总觉得写博客要先想好标题、结构、配图，结果往往在打开编辑器之前就已经累了。可今天不一样，我只需要把脑海里的碎片慢慢说出来，它就开始帮我整理顺序、补齐页面、把想法落成真正能发布的文章。</p>
+<h2 id="像搭档一样一起修改"><a href="#像搭档一样一起修改" class="headerlink" title="像搭档一样一起修改"></a>像搭档一样一起修改</h2><p>最有意思的不是“它写得有多快”，而是这种协作感。它会先理解我真正想表达的情绪，再把这些情绪铺成段落：今天为什么想记下这趟 Codex 之旅、我在仓库里看到了什么、以及当页面真的出现在博客首页时那种轻轻落地的满足感。写到这里，我突然觉得技术和生活其实没有离得很远，工具也可以有温度。</p>
+<h2 id="今天留下一个温柔的句号"><a href="#今天留下一个温柔的句号" class="headerlink" title="今天留下一个温柔的句号"></a>今天留下一个温柔的句号</h2><p>这篇文章不算什么惊天动地的大工程，却像是给今天认真留了一个坐标。以后再回头看，也许我会想起这个周末的夜晚：我坐在屏幕前，一边和 Codex 对话，一边把零散的心情整理成一页静静发光的网页。希望以后还能继续写下去，继续记录这些看似普通、其实很珍贵的瞬间。</p>
 
     </div>
 
@@ -317,8 +321,8 @@
     <footer class="post-footer">
         <div class="post-nav">
           <div class="post-nav-next post-nav-item">
-              <a href="/2019/08/15/KNN/" rel="next" title="KNN——机器学习">
-                <i class="fa fa-chevron-left"></i> KNN——机器学习
+              <a href="/2023/04/17/20230417/" rel="next" title="晚安坂本龙一先生">
+                <i class="fa fa-chevron-left"></i> 晚安坂本龙一先生
               </a>
             
           </div>
@@ -326,10 +330,6 @@
           <span class="post-nav-divider"></span>
 
           <div class="post-nav-prev post-nav-item">
-              <a href="/2019/11/11/hjmgxl/" rel="prev" title="好久没有更新辣">
-                好久没有更新辣 <i class="fa fa-chevron-right"></i>
-              </a>
-            
           </div>
         </div>
     </footer>
@@ -494,7 +494,7 @@
             
 
             
-              <div class="post-toc-content"><ol class="nav"><li class="nav-item nav-level-2"><a class="nav-link" href="#中秋节"><span class="nav-number">1.</span> <span class="nav-text">中秋节</span></a></li></ol></div>
+              <div class="post-toc-content"><ol class="nav"><li class="nav-item nav-level-2"><a class="nav-link" href="#把一个念头交给-Codex"><span class="nav-number">1.</span> <span class="nav-text">把一个念头交给 Codex</span></a></li><li class="nav-item nav-level-2"><a class="nav-link" href="#像搭档一样一起修改"><span class="nav-number">2.</span> <span class="nav-text">像搭档一样一起修改</span></a></li><li class="nav-item nav-level-2"><a class="nav-link" href="#今天留下一个温柔的句号"><span class="nav-number">3.</span> <span class="nav-text">今天留下一个温柔的句号</span></a></li></ol></div>
             
 
           </div>

--- a/about/index.html
+++ b/about/index.html
@@ -336,7 +336,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2019/08/index.html
+++ b/archives/2019/08/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -494,7 +494,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2019/09/index.html
+++ b/archives/2019/09/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2019/11/index.html
+++ b/archives/2019/11/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -386,7 +386,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2019/index.html
+++ b/archives/2019/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -602,7 +602,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2020/01/index.html
+++ b/archives/2020/01/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2020/02/index.html
+++ b/archives/2020/02/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2020/03/index.html
+++ b/archives/2020/03/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2020/05/index.html
+++ b/archives/2020/05/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2020/11/index.html
+++ b/archives/2020/11/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2020/index.html
+++ b/archives/2020/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -494,7 +494,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2021/06/index.html
+++ b/archives/2021/06/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -386,7 +386,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2021/10/index.html
+++ b/archives/2021/10/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2021/index.html
+++ b/archives/2021/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -422,7 +422,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2022/01/index.html
+++ b/archives/2022/01/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2022/04/index.html
+++ b/archives/2022/04/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2022/06/index.html
+++ b/archives/2022/06/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -386,7 +386,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2022/07/index.html
+++ b/archives/2022/07/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2022/09/index.html
+++ b/archives/2022/09/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2022/10/index.html
+++ b/archives/2022/10/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2022/12/index.html
+++ b/archives/2022/12/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2022/index.html
+++ b/archives/2022/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -602,7 +602,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2023/01/index.html
+++ b/archives/2023/01/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2023/04/index.html
+++ b/archives/2023/04/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -350,7 +350,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2023/index.html
+++ b/archives/2023/index.html
@@ -262,7 +262,7 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
       
 
@@ -386,7 +386,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/2026/03/index.html
+++ b/archives/2026/03/index.html
@@ -57,19 +57,15 @@
   };
 </script>
 
-  <meta name="description" content="中秋节happy~">
-<meta name="keywords" content="easy to clee happy life">
-<meta property="og:type" content="article">
-<meta property="og:title" content="大家中秋快乐啊">
-<meta property="og:url" content="http://yoursite.com/2019/09/14/zqkl/index.html">
+  <meta name="keywords" content="easy to clee happy life">
+<meta property="og:type" content="website">
+<meta property="og:title" content="saber~">
+<meta property="og:url" content="http://yoursite.com/archives/2026/03/index.html">
 <meta property="og:site_name" content="saber~">
-<meta property="og:description" content="中秋节happy~">
 <meta property="og:locale" content="zh-CN">
-<meta property="og:updated_time" content="2019-09-14T05:02:59.009Z">
 <meta name="twitter:card" content="summary">
-<meta name="twitter:title" content="大家中秋快乐啊">
-<meta name="twitter:description" content="中秋节happy~">
-  <link rel="canonical" href="http://yoursite.com/2019/09/14/zqkl/">
+<meta name="twitter:title" content="saber~">
+  <link rel="canonical" href="http://yoursite.com/archives/2026/03/">
 
 
 <script id="page.configurations">
@@ -78,7 +74,7 @@
   };
 </script>
 
-  <title>大家中秋快乐啊 | saber~</title>
+  <title>归档 | saber~</title>
   
 
 
@@ -117,7 +113,7 @@
 
 <body itemscope itemtype="http://schema.org/WebPage" lang="zh-CN">
 
-  <div class="container sidebar-position-left page-post-detail">
+  <div class="container sidebar-position-left page-archive">
     <div class="headband"></div>
 
     <header id="header" class="header" itemscope itemtype="http://schema.org/WPHeader">
@@ -185,7 +181,7 @@
         
         
           
-          <li class="menu-item menu-item-archives">
+          <li class="menu-item menu-item-archives menu-item-active">
       
     
 
@@ -200,6 +196,24 @@
       
     </ul>
     
+
+    
+    
+      
+      
+    
+      
+      
+    
+      
+      
+    
+      
+      
+    
+    
+
+  
 
     <div class="site-search">
       
@@ -236,115 +250,67 @@
           <div id="content" class="content">
             
 
-  <div id="posts" class="posts-expand">
-    
-
-  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
   
   
   
-  <div class="post-block">
-    <link itemprop="mainEntityOfPage" href="http://yoursite.com/2019/09/14/zqkl/">
-
-    <span hidden itemprop="author" itemscope itemtype="http://schema.org/Person">
-      <meta itemprop="name" content="machi">
-      <meta itemprop="description" content="">
-      <meta itemprop="image" content="/images/saber_cute.png">
-    </span>
-
-    <span hidden itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
-      <meta itemprop="name" content="saber~">
-    </span>
-      <header class="post-header">
-
+  <div class="post-block archive">
+    <div id="posts" class="posts-collapse">
+      <span class="archive-move-on"></span>
+      <span class="archive-page-counter">
         
-          <h1 class="post-title" itemprop="name headline">大家中秋快乐啊
-
-              
-            
-          </h1>
         
-
-        <div class="post-meta">
-            <span class="post-meta-item">
-              <span class="post-meta-item-icon">
-                <i class="fa fa-calendar-o"></i>
-              </span>
-              
-                <span class="post-meta-item-text">发表于</span>
-              
-
-              
-                
-              
-
-              <time title="创建时间：2019-09-14 13:00:51 / 修改时间：13:02:59" itemprop="dateCreated datePublished" datetime="2019-09-14T13:00:51+08:00">2019-09-14</time>
-            </span>
+        
           
-            
-
-            
-          
-
-          
-            <span class="post-meta-item">
-              <span class="post-meta-item-icon"
-              >
-                <i class="fa fa-eye"></i>
-                 阅读次数： 
-                <span class="busuanzi-value" id="busuanzi_value_page_pv"></span>
-              </span>
-            </span>
-          <br>
-
-        </div>
-      </header>
-
-    
-    
-    
-    <div class="post-body" itemprop="articleBody">
+        
+        嗯..! 目前共计 27 篇日志。 继续努力。
+      </span>
 
       
-        <h2 id="中秋节"><a href="#中秋节" class="headerlink" title="中秋节"></a>中秋节</h2><p>happy~</p>
 
-    </div>
-
-    
-    
-    
-
-    <footer class="post-footer">
-        <div class="post-nav">
-          <div class="post-nav-next post-nav-item">
-              <a href="/2019/08/15/KNN/" rel="next" title="KNN——机器学习">
-                <i class="fa fa-chevron-left"></i> KNN——机器学习
-              </a>
-            
+        
+          <div class="collection-title">
+            <h1 class="archive-year" id="archive-year-2026">2026</h1>
           </div>
+        
 
-          <span class="post-nav-divider"></span>
+        
 
-          <div class="post-nav-prev post-nav-item">
-              <a href="/2019/11/11/hjmgxl/" rel="prev" title="好久没有更新辣">
-                好久没有更新辣 <i class="fa fa-chevron-right"></i>
-              </a>
+  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
+    <header class="post-header">
+
+      <h2 class="post-title">
+          <a class="post-title-link" href="/2026/03/21/codex-journey/" itemprop="url">
             
-          </div>
-        </div>
-    </footer>
-  </div>
-  
-  
-  
+              <span itemprop="name">今天和 Codex 一起写博客</span>
+            
+          </a>
+        
+      </h2>
+
+      <div class="post-meta">
+        <time class="post-time" itemprop="dateCreated"
+              datetime="2026-03-21T20:26:00+08:00"
+              content="2026-03-21">
+          03-21
+        </time>
+      </div>
+
+    </header>
   </article>
 
+
+    </div>
   </div>
+  
+  
+  
+
+  
+
 
 
           </div>
           
-
 
         </div>
           
@@ -360,17 +326,8 @@
 </iframe>
   <aside id="sidebar" class="sidebar">
     <div class="sidebar-inner">
-        <ul class="sidebar-nav motion-element">
-          <li class="sidebar-nav-toc sidebar-nav-active" data-target="post-toc-wrap">
-            文章目录
-          </li>
-          <li class="sidebar-nav-overview" data-target="site-overview-wrap">
-            站点概览
-          </li>
-        </ul>
-      
 
-      <div class="site-overview-wrap sidebar-panel">
+      <div class="site-overview-wrap sidebar-panel sidebar-panel-active">
         <div class="site-overview">
 
           <div class="site-author motion-element" itemprop="author" itemscope itemtype="http://schema.org/Person">
@@ -484,23 +441,6 @@
 
         </div>
       </div>
-      <!--noindex-->
-        <div class="post-toc-wrap motion-element sidebar-panel sidebar-panel-active">
-          <div class="post-toc">
-
-            
-            
-            
-            
-
-            
-              <div class="post-toc-content"><ol class="nav"><li class="nav-item nav-level-2"><a class="nav-link" href="#中秋节"><span class="nav-number">1.</span> <span class="nav-text">中秋节</span></a></li></ol></div>
-            
-
-          </div>
-        </div>
-      <!--/noindex-->
-      
 
     </div>
   </aside>
@@ -579,10 +519,6 @@
 
 
   
-  <script src="/js/scrollspy.js?v=7.3.0"></script>
-<script src="/js/post-details.js?v=7.3.0"></script>
-
-
 
   <script src="/js/next-boot.js?v=7.3.0"></script>
 

--- a/archives/2026/index.html
+++ b/archives/2026/index.html
@@ -57,19 +57,15 @@
   };
 </script>
 
-  <meta name="description" content="中秋节happy~">
-<meta name="keywords" content="easy to clee happy life">
-<meta property="og:type" content="article">
-<meta property="og:title" content="大家中秋快乐啊">
-<meta property="og:url" content="http://yoursite.com/2019/09/14/zqkl/index.html">
+  <meta name="keywords" content="easy to clee happy life">
+<meta property="og:type" content="website">
+<meta property="og:title" content="saber~">
+<meta property="og:url" content="http://yoursite.com/archives/2026/index.html">
 <meta property="og:site_name" content="saber~">
-<meta property="og:description" content="中秋节happy~">
 <meta property="og:locale" content="zh-CN">
-<meta property="og:updated_time" content="2019-09-14T05:02:59.009Z">
 <meta name="twitter:card" content="summary">
-<meta name="twitter:title" content="大家中秋快乐啊">
-<meta name="twitter:description" content="中秋节happy~">
-  <link rel="canonical" href="http://yoursite.com/2019/09/14/zqkl/">
+<meta name="twitter:title" content="saber~">
+  <link rel="canonical" href="http://yoursite.com/archives/2026/">
 
 
 <script id="page.configurations">
@@ -78,7 +74,7 @@
   };
 </script>
 
-  <title>大家中秋快乐啊 | saber~</title>
+  <title>归档 | saber~</title>
   
 
 
@@ -117,7 +113,7 @@
 
 <body itemscope itemtype="http://schema.org/WebPage" lang="zh-CN">
 
-  <div class="container sidebar-position-left page-post-detail">
+  <div class="container sidebar-position-left page-archive">
     <div class="headband"></div>
 
     <header id="header" class="header" itemscope itemtype="http://schema.org/WPHeader">
@@ -185,7 +181,7 @@
         
         
           
-          <li class="menu-item menu-item-archives">
+          <li class="menu-item menu-item-archives menu-item-active">
       
     
 
@@ -200,6 +196,24 @@
       
     </ul>
     
+
+    
+    
+      
+      
+    
+      
+      
+    
+      
+      
+    
+      
+      
+    
+    
+
+  
 
     <div class="site-search">
       
@@ -236,115 +250,67 @@
           <div id="content" class="content">
             
 
-  <div id="posts" class="posts-expand">
-    
-
-  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
   
   
   
-  <div class="post-block">
-    <link itemprop="mainEntityOfPage" href="http://yoursite.com/2019/09/14/zqkl/">
-
-    <span hidden itemprop="author" itemscope itemtype="http://schema.org/Person">
-      <meta itemprop="name" content="machi">
-      <meta itemprop="description" content="">
-      <meta itemprop="image" content="/images/saber_cute.png">
-    </span>
-
-    <span hidden itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
-      <meta itemprop="name" content="saber~">
-    </span>
-      <header class="post-header">
-
+  <div class="post-block archive">
+    <div id="posts" class="posts-collapse">
+      <span class="archive-move-on"></span>
+      <span class="archive-page-counter">
         
-          <h1 class="post-title" itemprop="name headline">大家中秋快乐啊
-
-              
-            
-          </h1>
         
-
-        <div class="post-meta">
-            <span class="post-meta-item">
-              <span class="post-meta-item-icon">
-                <i class="fa fa-calendar-o"></i>
-              </span>
-              
-                <span class="post-meta-item-text">发表于</span>
-              
-
-              
-                
-              
-
-              <time title="创建时间：2019-09-14 13:00:51 / 修改时间：13:02:59" itemprop="dateCreated datePublished" datetime="2019-09-14T13:00:51+08:00">2019-09-14</time>
-            </span>
+        
           
-            
-
-            
-          
-
-          
-            <span class="post-meta-item">
-              <span class="post-meta-item-icon"
-              >
-                <i class="fa fa-eye"></i>
-                 阅读次数： 
-                <span class="busuanzi-value" id="busuanzi_value_page_pv"></span>
-              </span>
-            </span>
-          <br>
-
-        </div>
-      </header>
-
-    
-    
-    
-    <div class="post-body" itemprop="articleBody">
+        
+        嗯..! 目前共计 27 篇日志。 继续努力。
+      </span>
 
       
-        <h2 id="中秋节"><a href="#中秋节" class="headerlink" title="中秋节"></a>中秋节</h2><p>happy~</p>
 
-    </div>
-
-    
-    
-    
-
-    <footer class="post-footer">
-        <div class="post-nav">
-          <div class="post-nav-next post-nav-item">
-              <a href="/2019/08/15/KNN/" rel="next" title="KNN——机器学习">
-                <i class="fa fa-chevron-left"></i> KNN——机器学习
-              </a>
-            
+        
+          <div class="collection-title">
+            <h1 class="archive-year" id="archive-year-2026">2026</h1>
           </div>
+        
 
-          <span class="post-nav-divider"></span>
+        
 
-          <div class="post-nav-prev post-nav-item">
-              <a href="/2019/11/11/hjmgxl/" rel="prev" title="好久没有更新辣">
-                好久没有更新辣 <i class="fa fa-chevron-right"></i>
-              </a>
+  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
+    <header class="post-header">
+
+      <h2 class="post-title">
+          <a class="post-title-link" href="/2026/03/21/codex-journey/" itemprop="url">
             
-          </div>
-        </div>
-    </footer>
-  </div>
-  
-  
-  
+              <span itemprop="name">今天和 Codex 一起写博客</span>
+            
+          </a>
+        
+      </h2>
+
+      <div class="post-meta">
+        <time class="post-time" itemprop="dateCreated"
+              datetime="2026-03-21T20:26:00+08:00"
+              content="2026-03-21">
+          03-21
+        </time>
+      </div>
+
+    </header>
   </article>
 
+
+    </div>
   </div>
+  
+  
+  
+
+  
+
 
 
           </div>
           
-
 
         </div>
           
@@ -360,17 +326,8 @@
 </iframe>
   <aside id="sidebar" class="sidebar">
     <div class="sidebar-inner">
-        <ul class="sidebar-nav motion-element">
-          <li class="sidebar-nav-toc sidebar-nav-active" data-target="post-toc-wrap">
-            文章目录
-          </li>
-          <li class="sidebar-nav-overview" data-target="site-overview-wrap">
-            站点概览
-          </li>
-        </ul>
-      
 
-      <div class="site-overview-wrap sidebar-panel">
+      <div class="site-overview-wrap sidebar-panel sidebar-panel-active">
         <div class="site-overview">
 
           <div class="site-author motion-element" itemprop="author" itemscope itemtype="http://schema.org/Person">
@@ -484,23 +441,6 @@
 
         </div>
       </div>
-      <!--noindex-->
-        <div class="post-toc-wrap motion-element sidebar-panel sidebar-panel-active">
-          <div class="post-toc">
-
-            
-            
-            
-            
-
-            
-              <div class="post-toc-content"><ol class="nav"><li class="nav-item nav-level-2"><a class="nav-link" href="#中秋节"><span class="nav-number">1.</span> <span class="nav-text">中秋节</span></a></li></ol></div>
-            
-
-          </div>
-        </div>
-      <!--/noindex-->
-      
 
     </div>
   </aside>
@@ -579,10 +519,6 @@
 
 
   
-  <script src="/js/scrollspy.js?v=7.3.0"></script>
-<script src="/js/post-details.js?v=7.3.0"></script>
-
-
 
   <script src="/js/next-boot.js?v=7.3.0"></script>
 

--- a/archives/index.html
+++ b/archives/index.html
@@ -262,20 +262,49 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
+
       
 
         
-        
+          <div class="collection-title">
+            <h1 class="archive-year" id="archive-year-2026">2026</h1>
+          </div>
         
 
         
-          
+
+  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
+    <header class="post-header">
+
+      <h2 class="post-title">
+          <a class="post-title-link" href="/2026/03/21/codex-journey/" itemprop="url">
+            
+              <span itemprop="name">今天和 Codex 一起写博客</span>
+            
+          </a>
+        
+      </h2>
+
+      <div class="post-meta">
+        <time class="post-time" itemprop="dateCreated"
+              datetime="2026-03-21T20:26:00+08:00"
+              content="2026-03-21">
+          03-21
+        </time>
+      </div>
+
+    </header>
+  </article>
+
+
+      
+
+        
           <div class="collection-title">
             <h1 class="archive-year" id="archive-year-2023">2023</h1>
           </div>
-        
         
 
         
@@ -304,18 +333,6 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
 
@@ -340,19 +357,12 @@
   </article>
 
 
-
       
 
         
-        
-        
-
-        
-          
           <div class="collection-title">
             <h1 class="archive-year" id="archive-year-2022">2022</h1>
           </div>
-        
         
 
         
@@ -381,18 +391,6 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
 
@@ -416,18 +414,6 @@
     </header>
   </article>
 
-
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
@@ -453,18 +439,6 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
 
@@ -488,18 +462,6 @@
     </header>
   </article>
 
-
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
@@ -525,18 +487,6 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
 
@@ -560,18 +510,6 @@
     </header>
   </article>
 
-
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
@@ -597,53 +535,7 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
-  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
-    <header class="post-header">
-
-      <h2 class="post-title">
-          <a class="post-title-link" href="/2022/01/21/20220121/" itemprop="url">
-            
-              <span itemprop="name">又是一个周五</span>
-            
-          </a>
-        
-      </h2>
-
-      <div class="post-meta">
-        <time class="post-time" itemprop="dateCreated"
-              datetime="2022-01-21T14:42:34+08:00"
-              content="2022-01-21">
-          01-21
-        </time>
-      </div>
-
-    </header>
-  </article>
-
-
-
-      
-
-    </div>
-  </div>
-  
-  
-  
-
-  
-  <nav class="pagination">
+      <nav class="pagination">
     <span class="page-number current">1</span><a class="page-number" href="/archives/page/2/">2</a><a class="page-number" href="/archives/page/3/">3</a><a class="extend next" rel="next" href="/archives/page/2/"><i class="fa fa-angle-right" aria-label="下一页"></i></a>
   </nav>
 
@@ -682,7 +574,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/page/2/index.html
+++ b/archives/page/2/index.html
@@ -262,20 +262,49 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
+
       
 
         
-        
+          <div class="collection-title">
+            <h1 class="archive-year" id="archive-year-2022">2022</h1>
+          </div>
         
 
         
-          
+
+  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
+    <header class="post-header">
+
+      <h2 class="post-title">
+          <a class="post-title-link" href="/2022/01/21/20220121/" itemprop="url">
+            
+              <span itemprop="name">又是一个周五</span>
+            
+          </a>
+        
+      </h2>
+
+      <div class="post-meta">
+        <time class="post-time" itemprop="dateCreated"
+              datetime="2022-01-21T14:42:34+08:00"
+              content="2022-01-21">
+          01-21
+        </time>
+      </div>
+
+    </header>
+  </article>
+
+
+      
+
+        
           <div class="collection-title">
             <h1 class="archive-year" id="archive-year-2021">2021</h1>
           </div>
-        
         
 
         
@@ -304,18 +333,6 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
 
@@ -339,18 +356,6 @@
     </header>
   </article>
 
-
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
@@ -376,19 +381,12 @@
   </article>
 
 
-
       
 
         
-        
-        
-
-        
-          
           <div class="collection-title">
             <h1 class="archive-year" id="archive-year-2020">2020</h1>
           </div>
-        
         
 
         
@@ -417,18 +415,6 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
 
@@ -452,18 +438,6 @@
     </header>
   </article>
 
-
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
@@ -489,18 +463,6 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
 
@@ -524,18 +486,6 @@
     </header>
   </article>
 
-
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
@@ -561,19 +511,12 @@
   </article>
 
 
-
       
 
         
-        
-        
-
-        
-          
           <div class="collection-title">
             <h1 class="archive-year" id="archive-year-2019">2019</h1>
           </div>
-        
         
 
         
@@ -602,53 +545,7 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
-  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
-    <header class="post-header">
-
-      <h2 class="post-title">
-          <a class="post-title-link" href="/2019/11/11/hjmgxl/" itemprop="url">
-            
-              <span itemprop="name">好久没有更新辣</span>
-            
-          </a>
-        
-      </h2>
-
-      <div class="post-meta">
-        <time class="post-time" itemprop="dateCreated"
-              datetime="2019-11-11T12:59:11+08:00"
-              content="2019-11-11">
-          11-11
-        </time>
-      </div>
-
-    </header>
-  </article>
-
-
-
-      
-
-    </div>
-  </div>
-  
-  
-  
-
-  
-  <nav class="pagination">
+      <nav class="pagination">
     <a class="extend prev" rel="prev" href="/archives/"><i class="fa fa-angle-left" aria-label="上一页"></i></a><a class="page-number" href="/archives/">1</a><span class="page-number current">2</span><a class="page-number" href="/archives/page/3/">3</a><a class="extend next" rel="next" href="/archives/page/3/"><i class="fa fa-angle-right" aria-label="下一页"></i></a>
   </nav>
 
@@ -687,7 +584,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/archives/page/3/index.html
+++ b/archives/page/3/index.html
@@ -262,23 +262,42 @@
         
           
         
-        嗯..! 目前共计 26 篇日志。 继续努力。
+        嗯..! 目前共计 27 篇日志。 继续努力。
       </span>
+
       
 
         
-        
-        
-
-        
-          
           <div class="collection-title">
             <h1 class="archive-year" id="archive-year-2019">2019</h1>
           </div>
         
-        
 
         
+
+  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
+    <header class="post-header">
+
+      <h2 class="post-title">
+          <a class="post-title-link" href="/2019/11/11/hjmgxl/" itemprop="url">
+            
+              <span itemprop="name">好久没有更新辣</span>
+            
+          </a>
+        
+      </h2>
+
+      <div class="post-meta">
+        <time class="post-time" itemprop="dateCreated"
+              datetime="2019-11-11T12:59:11+08:00"
+              content="2019-11-11">
+          11-11
+        </time>
+      </div>
+
+    </header>
+  </article>
+
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
@@ -304,18 +323,6 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
 
@@ -339,18 +346,6 @@
     </header>
   </article>
 
-
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
@@ -376,18 +371,6 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
 
@@ -411,18 +394,6 @@
     </header>
   </article>
 
-
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
@@ -448,18 +419,6 @@
   </article>
 
 
-
-      
-
-        
-        
-        
-
-        
-        
-
-        
-
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
 
@@ -484,17 +443,7 @@
   </article>
 
 
-
-      
-
-    </div>
-  </div>
-  
-  
-  
-
-  
-  <nav class="pagination">
+      <nav class="pagination">
     <a class="extend prev" rel="prev" href="/archives/page/2/"><i class="fa fa-angle-left" aria-label="上一页"></i></a><a class="page-number" href="/archives/">1</a><a class="page-number" href="/archives/page/2/">2</a><span class="page-number current">3</span>
   </nav>
 
@@ -533,7 +482,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/categories/index.html
+++ b/categories/index.html
@@ -331,7 +331,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/index.html
+++ b/index.html
@@ -232,6 +232,79 @@
           <div id="content" class="content">
             
   <section id="posts" class="posts-expand">
+
+
+  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
+  
+  
+  
+  <div class="post-block">
+    <link itemprop="mainEntityOfPage" href="http://yoursite.com/2026/03/21/codex-journey/">
+
+    <span hidden itemprop="author" itemscope itemtype="http://schema.org/Person">
+      <meta itemprop="name" content="machi">
+      <meta itemprop="description" content="">
+      <meta itemprop="image" content="/images/saber_cute.png">
+    </span>
+
+    <span hidden itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+      <meta itemprop="name" content="saber~">
+    </span>
+      <header class="post-header">
+
+        
+          <h1 class="post-title" itemprop="name headline">
+                
+                
+                <a href="/2026/03/21/codex-journey/" class="post-title-link" itemprop="url">今天和 Codex 一起写博客</a>
+              
+            
+          </h1>
+        
+
+        <div class="post-meta">
+            <span class="post-meta-item">
+              <span class="post-meta-item-icon">
+                <i class="fa fa-calendar-o"></i>
+              </span>
+              
+                <span class="post-meta-item-text">发表于</span>
+              
+
+              <time title="创建时间：2026-03-21 20:26:00 / 修改时间：20:26:00" itemprop="dateCreated datePublished" datetime="2026-03-21T20:26:00+08:00">2026-03-21</time>
+            </span>
+          
+
+          <br>
+
+        </div>
+      </header>
+
+    
+    
+    
+    <div class="post-body" itemprop="articleBody">
+
+      
+          
+            <h2 id="把一个念头交给-Codex"><a href="#把一个念头交给-Codex" class="headerlink" title="把一个念头交给 Codex"></a>把一个念头交给 Codex</h2><p>2026 年 3 月 21 日，我做了一件很简单、又让我有点兴奋的事情：把“想写一篇博客”这个念头交给了 Codex。以前我总觉得写博客要先想好标题、结构、配图，结果往往在打开编辑器之前就已经累了。可今天不一样，我只需要把脑海里的碎片慢慢说出来，它就开始帮我整理顺序、补齐页面、把想法落成真正能发布的文章。</p>
+<h2 id="像搭档一样一起修改"><a href="#像搭档一样一起修改" class="headerlink" title="像搭档一样一起修改"></a>像搭档一样一起修改</h2><p>最有意思的不是“它写得有多快”，而是这种协作感。它会先理解我真正想表达的情绪，再把这些情绪铺成段落：今天为什么想记下这趟 Codex 之旅、我在仓库里看到了什么、以及当页面真的出现在博客首页时那种轻轻落地的满足感。写到这里，我突然觉得技术和生活其实没有离得很远，工具也可以有温度。</p>
+<h2 id="今天留下一个温柔的句号"><a href="#今天留下一个温柔的句号" class="headerlink" title="今天留下一个温柔的句号"></a>今天留下一个温柔的句号</h2><p>这篇文章不算什么惊天动地的大工程，却像是给今天认真留了一个坐标。以后再回头看，也许我会想起这个周末的夜晚：我坐在屏幕前，一边和 Codex 对话，一边把零散的心情整理成一页静静发光的网页。希望以后还能继续写下去，继续记录这些看似普通、其实很珍贵的瞬间。</p>
+
+          
+        
+      
+    </div>
+
+    <footer class="post-footer">
+        <div class="post-eof"></div>
+    </footer>
+  </div>
+  
+  
+  
+  </article>
+
       
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
@@ -1017,94 +1090,7 @@
   </article>
 
     
-      
-
-  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
-  
-  
-  
-  <div class="post-block">
-    <link itemprop="mainEntityOfPage" href="http://yoursite.com/2022/01/21/20220121/">
-
-    <span hidden itemprop="author" itemscope itemtype="http://schema.org/Person">
-      <meta itemprop="name" content="machi">
-      <meta itemprop="description" content="">
-      <meta itemprop="image" content="/images/saber_cute.png">
-    </span>
-
-    <span hidden itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
-      <meta itemprop="name" content="saber~">
-    </span>
-      <header class="post-header">
-
-        
-          <h1 class="post-title" itemprop="name headline">
-                
-                
-                <a href="/2022/01/21/20220121/" class="post-title-link" itemprop="url">又是一个周五</a>
-              
-            
-          </h1>
-        
-
-        <div class="post-meta">
-            <span class="post-meta-item">
-              <span class="post-meta-item-icon">
-                <i class="fa fa-calendar-o"></i>
-              </span>
-              
-                <span class="post-meta-item-text">发表于</span>
-              
-
-              
-                
-              
-
-              <time title="创建时间：2022-01-21 14:42:34 / 修改时间：14:44:07" itemprop="dateCreated datePublished" datetime="2022-01-21T14:42:34+08:00">2022-01-21</time>
-            </span>
-          
-            
-
-            
-          
-
-          <br>
-
-        </div>
-      </header>
-
-    
-    
-    
-    <div class="post-body" itemprop="articleBody">
-
-      
-          
-            <h2 id="周末快乐"><a href="#周末快乐" class="headerlink" title="周末快乐"></a>周末快乐</h2><p>后天去和朋友搓麻将，直接虐杀他们!<br>明天公司还有年会，求一个一等奖</p>
-
-          
-        
-      
-    </div>
-
-    
-    
-    
-
-    <footer class="post-footer">
-        <div class="post-eof"></div>
-    </footer>
-  </div>
-  
-  
-  
-  </article>
-
-    
-  </section>
-
-  
-  <nav class="pagination">
+<nav class="pagination">
     <span class="page-number current">1</span><a class="page-number" href="/page/2/">2</a><a class="page-number" href="/page/3/">3</a><a class="extend next" rel="next" href="/page/2/"><i class="fa fa-angle-right" aria-label="下一页"></i></a>
   </nav>
 
@@ -1142,7 +1128,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/page/2/index.html
+++ b/page/2/index.html
@@ -232,6 +232,91 @@
           <div id="content" class="content">
             
   <section id="posts" class="posts-expand">
+
+    
+      
+
+  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
+  
+  
+  
+  <div class="post-block">
+    <link itemprop="mainEntityOfPage" href="http://yoursite.com/2022/01/21/20220121/">
+
+    <span hidden itemprop="author" itemscope itemtype="http://schema.org/Person">
+      <meta itemprop="name" content="machi">
+      <meta itemprop="description" content="">
+      <meta itemprop="image" content="/images/saber_cute.png">
+    </span>
+
+    <span hidden itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+      <meta itemprop="name" content="saber~">
+    </span>
+      <header class="post-header">
+
+        
+          <h1 class="post-title" itemprop="name headline">
+                
+                
+                <a href="/2022/01/21/20220121/" class="post-title-link" itemprop="url">又是一个周五</a>
+              
+            
+          </h1>
+        
+
+        <div class="post-meta">
+            <span class="post-meta-item">
+              <span class="post-meta-item-icon">
+                <i class="fa fa-calendar-o"></i>
+              </span>
+              
+                <span class="post-meta-item-text">发表于</span>
+              
+
+              
+                
+              
+
+              <time title="创建时间：2022-01-21 14:42:34 / 修改时间：14:44:07" itemprop="dateCreated datePublished" datetime="2022-01-21T14:42:34+08:00">2022-01-21</time>
+            </span>
+          
+            
+
+            
+          
+
+          <br>
+
+        </div>
+      </header>
+
+    
+    
+    
+    <div class="post-body" itemprop="articleBody">
+
+      
+          
+            <h2 id="周末快乐"><a href="#周末快乐" class="headerlink" title="周末快乐"></a>周末快乐</h2><p>后天去和朋友搓麻将，直接虐杀他们!<br>明天公司还有年会，求一个一等奖</p>
+
+          
+        
+      
+    </div>
+
+    
+    
+    
+
+    <footer class="post-footer">
+        <div class="post-eof"></div>
+    </footer>
+  </div>
+  
+  
+  
+  </article>
+
       
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
@@ -1003,94 +1088,7 @@
   </article>
 
     
-      
-
-  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
-  
-  
-  
-  <div class="post-block">
-    <link itemprop="mainEntityOfPage" href="http://yoursite.com/2019/11/11/hjmgxl/">
-
-    <span hidden itemprop="author" itemscope itemtype="http://schema.org/Person">
-      <meta itemprop="name" content="machi">
-      <meta itemprop="description" content="">
-      <meta itemprop="image" content="/images/saber_cute.png">
-    </span>
-
-    <span hidden itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
-      <meta itemprop="name" content="saber~">
-    </span>
-      <header class="post-header">
-
-        
-          <h1 class="post-title" itemprop="name headline">
-                
-                
-                <a href="/2019/11/11/hjmgxl/" class="post-title-link" itemprop="url">好久没有更新辣</a>
-              
-            
-          </h1>
-        
-
-        <div class="post-meta">
-            <span class="post-meta-item">
-              <span class="post-meta-item-icon">
-                <i class="fa fa-calendar-o"></i>
-              </span>
-              
-                <span class="post-meta-item-text">发表于</span>
-              
-
-              
-                
-              
-
-              <time title="创建时间：2019-11-11 12:59:11 / 修改时间：13:10:32" itemprop="dateCreated datePublished" datetime="2019-11-11T12:59:11+08:00">2019-11-11</time>
-            </span>
-          
-            
-
-            
-          
-
-          <br>
-
-        </div>
-      </header>
-
-    
-    
-    
-    <div class="post-body" itemprop="articleBody">
-
-      
-          
-            <h4 id="这真的是一个题目"><a href="#这真的是一个题目" class="headerlink" title="这真的是一个题目"></a>这真的是一个题目</h4><p>近些天沉迷wow，实在是太好玩了。<br>最近还在准备六级，这次必定拿下六级。<br>认识了一个成都的小姐姐真开心啊！<br>还有这个1km跑步始终是个梗，不知道是身体变差了还是老了。加油加油~<br>那就下次再见吧。<br><img src="https://i.loli.net/2019/11/11/lDkeaJHz84NRnxu.jpg" alt="snapseed-01.jpeg"></p>
-
-          
-        
-      
-    </div>
-
-    
-    
-    
-
-    <footer class="post-footer">
-        <div class="post-eof"></div>
-    </footer>
-  </div>
-  
-  
-  
-  </article>
-
-    
-  </section>
-
-  
-  <nav class="pagination">
+<nav class="pagination">
     <a class="extend prev" rel="prev" href="/"><i class="fa fa-angle-left" aria-label="上一页"></i></a><a class="page-number" href="/">1</a><span class="page-number current">2</span><a class="page-number" href="/page/3/">3</a><a class="extend next" rel="next" href="/page/3/"><i class="fa fa-angle-right" aria-label="下一页"></i></a>
   </nav>
 
@@ -1128,7 +1126,7 @@
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>

--- a/page/3/index.html
+++ b/page/3/index.html
@@ -232,6 +232,91 @@
           <div id="content" class="content">
             
   <section id="posts" class="posts-expand">
+
+    
+      
+
+  <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
+  
+  
+  
+  <div class="post-block">
+    <link itemprop="mainEntityOfPage" href="http://yoursite.com/2019/11/11/hjmgxl/">
+
+    <span hidden itemprop="author" itemscope itemtype="http://schema.org/Person">
+      <meta itemprop="name" content="machi">
+      <meta itemprop="description" content="">
+      <meta itemprop="image" content="/images/saber_cute.png">
+    </span>
+
+    <span hidden itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+      <meta itemprop="name" content="saber~">
+    </span>
+      <header class="post-header">
+
+        
+          <h1 class="post-title" itemprop="name headline">
+                
+                
+                <a href="/2019/11/11/hjmgxl/" class="post-title-link" itemprop="url">好久没有更新辣</a>
+              
+            
+          </h1>
+        
+
+        <div class="post-meta">
+            <span class="post-meta-item">
+              <span class="post-meta-item-icon">
+                <i class="fa fa-calendar-o"></i>
+              </span>
+              
+                <span class="post-meta-item-text">发表于</span>
+              
+
+              
+                
+              
+
+              <time title="创建时间：2019-11-11 12:59:11 / 修改时间：13:10:32" itemprop="dateCreated datePublished" datetime="2019-11-11T12:59:11+08:00">2019-11-11</time>
+            </span>
+          
+            
+
+            
+          
+
+          <br>
+
+        </div>
+      </header>
+
+    
+    
+    
+    <div class="post-body" itemprop="articleBody">
+
+      
+          
+            <h4 id="这真的是一个题目"><a href="#这真的是一个题目" class="headerlink" title="这真的是一个题目"></a>这真的是一个题目</h4><p>近些天沉迷wow，实在是太好玩了。<br>最近还在准备六级，这次必定拿下六级。<br>认识了一个成都的小姐姐真开心啊！<br>还有这个1km跑步始终是个梗，不知道是身体变差了还是老了。加油加油~<br>那就下次再见吧。<br><img src="https://i.loli.net/2019/11/11/lDkeaJHz84NRnxu.jpg" alt="snapseed-01.jpeg"></p>
+
+          
+        
+      
+    </div>
+
+    
+    
+    
+
+    <footer class="post-footer">
+        <div class="post-eof"></div>
+    </footer>
+  </div>
+  
+  
+  
+  </article>
+
       
 
   <article class="post post-type-normal" itemscope itemtype="http://schema.org/Article">
@@ -831,10 +916,7 @@ print(&quot;W: %s b: %s loss: %s&quot;%(curr_W, curr_b, curr_loss))</code></pre>
   </article>
 
     
-  </section>
-
-  
-  <nav class="pagination">
+<nav class="pagination">
     <a class="extend prev" rel="prev" href="/page/2/"><i class="fa fa-angle-left" aria-label="上一页"></i></a><a class="page-number" href="/">1</a><a class="page-number" href="/page/2/">2</a><span class="page-number current">3</span>
   </nav>
 
@@ -872,7 +954,7 @@ print(&quot;W: %s b: %s loss: %s&quot;%(curr_W, curr_b, curr_loss))</code></pre>
         
           <a href="/archives/">
         
-          <span class="site-state-item-count">26</span>
+          <span class="site-state-item-count">27</span>
           <span class="site-state-item-name">日志</span>
         </a>
       </div>


### PR DESCRIPTION
### Motivation
- 记录一次与 Codex 协作写作的经历并把结果发布为一篇新的博客文章。 
- 将新文章暴露在首页与归档中，保持站点的分页和归档一致性。 
- 同步站点显示的日志总数并修复上一篇/下一篇导航以保证阅读流畅。 

### Description
- 新增文章文件 `2026/03/21/codex-journey/index.html`，包含完整的页面元信息、目录和正文内容（《今天和 Codex 一起写博客》）。
- 在首页与列表页调整文章块顺序并在 `index.html`、`page/2/index.html`、`page/3/index.html` 中插入新文章以维持每页文章数为 `10/10/7` 的分页分配。
- 新增归档页 `archives/2026/index.html` 与 `archives/2026/03/index.html`，并在所有相关归档/侧边栏页面（`archives/*`, `about/index.html`, `categories/index.html` 等）将站点文章计数从 `26` 同步为 `27`。
- 更新已有文章 `2023/04/17/20230417/index.html` 的上一篇/下一篇导航指向新文章，并调整各页面的文章列表块（涉及多处 `archives` 和 `page` 页面）以保证归档与首页一致性。 

### Testing
- 运行并通过了一个 Python 验证脚本，该脚本检查若干关键页面包含预期链接/标题并验证分页中文章块计数（`index.html`、`page/2/index.html`、`page/3/index.html` 为 `10/10/7`）；结果为通过。 
- 使用 `python -m http.server` 启动本地静态服务器并用 `curl -I` 请求新页面 `http://127.0.0.1:8000/2026/03/21/codex-journey/`，返回 HTTP 200，验证页面可被正确访问。 
- 对站点 HTML 执行全局替换与 grep/count 检查以确认归档条目与侧边栏计数已更新为 `27`，验证通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be778f7760832d900b6c44076efb11)